### PR TITLE
Filter out insecure cipher suites in TLS configuration

### DIFF
--- a/config/tls_config.go
+++ b/config/tls_config.go
@@ -61,6 +61,8 @@ func NewHubTLSConfig(settings *TLSSettings, logger watermill.LoggerAdapter) (*tl
 		InsecureSkipVerify: false,
 		RootCAs:            caCertPool,
 		MinVersion:         tls.VersionTLS12,
+		MaxVersion:         tls.VersionTLS13,
+		CipherSuites:       supportedCipherSuites(),
 	}
 
 	return cfg, noClean, nil
@@ -93,6 +95,8 @@ func NewFSTlsConfig(caCertPool *x509.CertPool, certFile, keyFile string) (*tls.C
 		RootCAs:            caCertPool,
 		Certificates:       []tls.Certificate{cert},
 		MinVersion:         tls.VersionTLS12,
+		MaxVersion:         tls.VersionTLS13,
+		CipherSuites:       supportedCipherSuites(),
 	}
 
 	return cfg, noClean, nil
@@ -145,4 +149,13 @@ func NewTPMTlsConfig(
 	}
 
 	return tlsConfig, closer, nil
+}
+
+func supportedCipherSuites() []uint16 {
+	cs := tls.CipherSuites()
+	cid := make([]uint16, len(cs))
+	for i := range cs {
+		cid[i] = cs[i].ID
+	}
+	return cid
 }

--- a/config/tls_config_test.go
+++ b/config/tls_config_test.go
@@ -12,6 +12,7 @@
 package config_test
 
 import (
+	"crypto/tls"
 	"testing"
 
 	"github.com/ThreeDotsLabs/watermill"
@@ -33,6 +34,18 @@ func TestUseCertificateSettingsOK(t *testing.T) {
 	use, _, err = config.NewFSTlsConfig(nil, certFile, keyFile)
 	require.NoError(t, err)
 	assert.True(t, len(use.Certificates) > 0)
+	assert.True(t, len(use.CipherSuites) > 0)
+	// assert that cipher suites identifiers are contained in tls.CipherSuites
+	for _, csID := range use.CipherSuites {
+		assert.True(t, func() bool {
+			for _, cs := range tls.CipherSuites() {
+				if cs.ID == csID {
+					return true
+				}
+			}
+			return false
+		}())
+	}
 
 	logger := watermill.NopLogger{}
 


### PR DESCRIPTION
[#6]  Filter out insecure cipher suites in TLS configuration
Signed-off-by: Hristo Bozhilov <Hristo.Bozhilov@bosch.io>