### PR TITLE
Update Eclipse Paho to version 1.4.1

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -153,6 +153,18 @@ golang.org/x/time (v0.0.0-20190308202827-9d24e82272b4)
 * Project: https://github.com/golang/time
 * Source:  https://github.com/golang/time/tree/9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
 
+golang.org/x/sync (v0.0.0-20210405180319-a5a99cb37ef4)
+
+* License: BSD 3-Clause "New" or "Revised" License
+* Project: https://github.com/golang/sync
+* Source:  https://github.com/golang/sync
+
+golang.org/x/sync (v0.0.0-20210220032951-036812b2e83c)
+
+* License: BSD 3-Clause "New" or "Revised" License
+* Project: https://github.com/golang/sync
+* Source:  https://github.com/golang/sync
+
 ## Cryptography
 
 Content may contain encryption software. The country in which you are currently

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -153,7 +153,7 @@ golang.org/x/time (v0.0.0-20190308202827-9d24e82272b4)
 * Project: https://github.com/golang/time
 * Source:  https://github.com/golang/time/tree/9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
 
-golang.org/x/sync (v0.0.0-20210220032951-036812b2e83)
+golang.org/x/sync (v0.0.0-20210220032951-036812b2e83c)
 
 * License: BSD 3-Clause "New" or "Revised" License
 * Project: https://github.com/golang/sync

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -153,7 +153,7 @@ golang.org/x/time (v0.0.0-20190308202827-9d24e82272b4)
 * Project: https://github.com/golang/time
 * Source:  https://github.com/golang/time/tree/9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
 
-golang.org/x/sync (v0.0.0-20210405180319-a5a99cb37ef4)
+golang.org/x/sync (v0.0.0-20210220032951-036812b2e83)
 
 * License: BSD 3-Clause "New" or "Revised" License
 * Project: https://github.com/golang/sync

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -159,12 +159,6 @@ golang.org/x/sync (v0.0.0-20210405180319-a5a99cb37ef4)
 * Project: https://github.com/golang/sync
 * Source:  https://github.com/golang/sync
 
-golang.org/x/sync (v0.0.0-20210220032951-036812b2e83c)
-
-* License: BSD 3-Clause "New" or "Revised" License
-* Project: https://github.com/golang/sync
-* Source:  https://github.com/golang/sync
-
 ## Cryptography
 
 Content may contain encryption software. The country in which you are currently

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -63,11 +63,11 @@ eclipse/ditto-clients-golang (0.0.0-20220225085802-cf3b306280d3)
 * Project: https://github.com/eclipse/ditto-clients-golang
 * Source:  https://github.com/eclipse/ditto-clients-golang/tree/cf3b306280d3453473ae8dd65e78f978e2c838ea
 
-eclipse/paho.mqtt.golang (1.3.5)
+eclipse/paho.mqtt.golang (1.4.1)
 
 * License: Eclipse Distribution License v1.0
 * Project: https://github.com/eclipse/paho.mqtt.golang
-* Source:  https://github.com/eclipse/paho.mqtt.golang/releases/tag/v1.3.5
+* Source:  https://github.com/eclipse/paho.mqtt.golang/releases/tag/v1.4.1
 
 fsnotify/fsnotify (1.5.1)
 

--- a/connector/connection.go
+++ b/connector/connection.go
@@ -136,6 +136,8 @@ func createClientOptions(config *Configuration, clientID string, cleanSession bo
 	if config.NoOpStore {
 		store := new(nostore)
 		clientOpts.SetStore(store)
+	} else {
+		clientOpts.SetStore(mqtt.NewOrderedMemoryStore())
 	}
 
 	return clientOpts

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ThreeDotsLabs/watermill v1.1.1
 	github.com/cenkalti/backoff/v3 v3.0.0
 	github.com/eclipse/ditto-clients-golang v0.0.0-20220225085802-cf3b306280d3
-	github.com/eclipse/paho.mqtt.golang v1.3.5
+	github.com/eclipse/paho.mqtt.golang v1.4.1
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/google/go-tpm v0.3.2
 	github.com/hashicorp/go-multierror v1.0.0
@@ -29,6 +29,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/lint v0.0.0-20190930215403-16217165b5de // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/tools v0.1.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,9 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/eclipse/ditto-clients-golang v0.0.0-20220225085802-cf3b306280d3 h1:bfFGs26yNSfhSi6xmnmykB0jZn1Vu5e1/7JA5Wu5aGc=
 github.com/eclipse/ditto-clients-golang v0.0.0-20220225085802-cf3b306280d3/go.mod h1:ey7YwfHSQJsinGkGbgeEgqZA7qJnoB0YiFVTFEY50Jg=
-github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqnNN1bdl41Y=
 github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
+github.com/eclipse/paho.mqtt.golang v1.4.1 h1:tUSpviiL5G3P9SZZJPC4ZULZJsxQKXxfENpMvdbAXAI=
+github.com/eclipse/paho.mqtt.golang v1.4.1/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -194,6 +195,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
 [#18] Update Eclipse Paho to version 1.4.1

Signed-off-by: Hristo Bozhilov <Hristo.Bozhilov@bosch.io>