### PR TITLE
Add default signal handler to HonoConnect

### DIFF
--- a/config/connections.go
+++ b/config/connections.go
@@ -379,11 +379,18 @@ func LocalConnect(ctx context.Context,
 }
 
 // HonoConnect connects to the Hub.
-func HonoConnect(sigs <-chan os.Signal,
+func HonoConnect(sigs chan os.Signal,
 	statusPub message.Publisher,
 	honoClient *conn.MQTTConnection,
 	logger logger.Logger,
 ) error {
+
+	if sigs == nil {
+		sigs = make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+		defer signal.Stop(sigs)
+	}
+
 	b := honoClient.ConnectBackoff()
 	b.Reset()
 

--- a/config/it_connections_test.go
+++ b/config/it_connections_test.go
@@ -86,5 +86,8 @@ func TestDummyHonoConnect(t *testing.T) {
 	}()
 
 	require.NoError(t, config.HonoConnect(sigs, statusPub, client, logger))
-	defer client.Disconnect()
+	client.Disconnect()
+
+	require.NoError(t, config.HonoConnect(nil, statusPub, client, logger))
+	client.Disconnect()
 }


### PR DESCRIPTION
[#32] Add default signal handler to HonoConnect


Signed-off-by: Hristo Bozhilov <Hristo.Bozhilov@bosch.io>