### PR TITLE
Remote MQTT endpoint CA certificate file should be optional

### DIFF
--- a/cmd/connector/launcher.go
+++ b/cmd/connector/launcher.go
@@ -103,7 +103,9 @@ func (l *launcher) Run(
 
 				reqCache.Close()
 
-				cleanup()
+				if cleanup != nil {
+					cleanup()
+				}
 
 				logger.Info("Messages router stopped", nil)
 				l.done <- true

--- a/config/connections.go
+++ b/config/connections.go
@@ -151,6 +151,18 @@ func CreateHubConnection(
 		honoConfig.BackoffMultiplier = mul
 	}
 
+	if len(settings.CACert) == 0 {
+		settings.UseCertificate = false
+		honoConfig.Credentials.UserName = util.NewHonoUserName(settings.AuthID, settings.TenantID)
+		honoConfig.Credentials.Password = settings.Password
+		conn, err := conn.NewMQTTConnection(honoConfig, settings.ClientID, logger)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return conn, nil, err
+	}
+
 	tlsConfig, cleaner, err := NewHubTLSConfig(&settings.TLSSettings, logger)
 	if err != nil {
 		return nil, nil, err
@@ -160,22 +172,21 @@ func CreateHubConnection(
 		settings.UseCertificate = false
 		honoConfig.Credentials.UserName = util.NewHonoUserName(settings.AuthID, settings.TenantID)
 		honoConfig.Credentials.Password = settings.Password
+	}
 
-	} else {
-		if len(settings.DeviceIDPattern) > 0 {
-			resolved, err := util.ReplacePattern(settings.DeviceIDPattern, tlsConfig.Certificates[0])
-			if err != nil {
-				defer cleaner()
-				return nil, nil, errors.Wrapf(err, "unable to resolve device ID pattern '%s'", settings.DeviceIDPattern)
-			}
-
-			if ns := model.NewNamespacedIDFrom(resolved); ns == nil {
-				defer cleaner()
-				return nil, nil, errors.Errorf("device ID '%s' has invalid namespace ID", resolved)
-			}
-
-			settings.DeviceID = resolved
+	if len(settings.DeviceIDPattern) > 0 {
+		resolved, err := util.ReplacePattern(settings.DeviceIDPattern, tlsConfig.Certificates[0])
+		if err != nil {
+			defer cleaner()
+			return nil, nil, errors.Wrapf(err, "unable to resolve device ID pattern '%s'", settings.DeviceIDPattern)
 		}
+
+		if ns := model.NewNamespacedIDFrom(resolved); ns == nil {
+			defer cleaner()
+			return nil, nil, errors.Errorf("device ID '%s' has invalid namespace ID", resolved)
+		}
+
+		settings.DeviceID = resolved
 	}
 
 	switch u.Scheme {

--- a/config/connections_test.go
+++ b/config/connections_test.go
@@ -44,8 +44,8 @@ func TestCreateHonoClientNoCacert(t *testing.T) {
 	require.NoError(t, settings.ValidateDynamic())
 	logger := testutil.NewLogger("testing", logger.DEBUG, t)
 	honoClient, _, err := config.CreateHubConnection(&settings.HubConnectionSettings, false, logger)
-	require.Error(t, err)
-	assert.Nil(t, honoClient)
+	require.NoError(t, err)
+	assert.NotNil(t, honoClient)
 }
 
 func TestCreateHonoClient(t *testing.T) {

--- a/config/settings.go
+++ b/config/settings.go
@@ -90,19 +90,28 @@ func (settings *Settings) ValidateStatic() error {
 		return err
 	}
 
-	if len(settings.CACert) > 0 && !util.FileExists(settings.CACert) {
-		return errors.Errorf("failed to read CA certificate file '%s'", settings.CACert)
-	}
-
-	if len(settings.DeviceIDPattern) > 0 {
-		if len(settings.DeviceID) > 0 {
-			return errors.Errorf(
-				"cannot use -deviceIdPattern flag value '%s' when -deviceId flag value '%s' is also provided",
-				settings.DeviceIDPattern, settings.DeviceID,
-			)
+	if len(settings.CACert) > 0 {
+		if !util.FileExists(settings.CACert) {
+			return errors.Errorf("failed to read CA certificate file '%s'", settings.CACert)
 		}
 
-		if len(settings.Cert) == 0 {
+		if len(settings.DeviceIDPattern) > 0 {
+			if len(settings.DeviceID) > 0 {
+				return errors.Errorf(
+					"cannot use -deviceIdPattern flag value '%s' when -deviceId flag value '%s' is also provided",
+					settings.DeviceIDPattern, settings.DeviceID,
+				)
+			}
+
+			if len(settings.Cert) == 0 {
+				return errors.Errorf(
+					"cannot use -deviceIdPattern flag value '%s' when the certificate file is not provided",
+					settings.DeviceIDPattern,
+				)
+			}
+		}
+	} else {
+		if len(settings.DeviceIDPattern) > 0 {
 			return errors.Errorf(
 				"cannot use -deviceIdPattern flag value '%s' when the certificate file is not provided",
 				settings.DeviceIDPattern,
@@ -119,9 +128,6 @@ func DefaultSettings() *Settings {
 		HubConnectionSettings: HubConnectionSettings{
 			Address:                 "mqtts://mqtt.bosch-iot-hub.com:8883",
 			AutoProvisioningEnabled: true,
-			TLSSettings: TLSSettings{
-				CACert: "iothub.crt",
-			},
 		},
 		LocalConnectionSettings: LocalConnectionSettings{
 			LocalAddress: "tcp://localhost:1883",

--- a/config/settings_test.go
+++ b/config/settings_test.go
@@ -193,7 +193,7 @@ func TestConfig(t *testing.T) {
 
 func TestDefaults(t *testing.T) {
 	settings := DefaultSettings()
-	assert.Error(t, settings.ValidateStatic())
+	assert.NoError(t, settings.ValidateStatic())
 
 	settings.CACert = "testdata/certificate.pem"
 	assert.NoError(t, settings.ValidateStatic())


### PR DESCRIPTION
[#34] Remote MQTT endpoint CA certificate file should be optional

Remove default value of CA certificate file


Signed-off-by: Avramova Antonia <antonia.avramova@bosch.io>