### PR TITLE
Install to /usr/bin

### DIFF
--- a/resources/suite-connector.service
+++ b/resources/suite-connector.service
@@ -7,7 +7,7 @@ Requires=mosquitto.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/suite-connector -configFile /etc/suite-connector/config.json
+ExecStart=/usr/bin/suite-connector -configFile /etc/suite-connector/config.json
 Restart=always
 
 [Install]


### PR DESCRIPTION
[#39] Install to /usr/bin

libostree requires all binaries installed using rpm to be in `/usr/bin` rather than `/usr/local/bin`