### PR TITLE
cacert configuration property/flag should be caCert

### DIFF
--- a/cmd/connector/it_main_test.go
+++ b/cmd/connector/it_main_test.go
@@ -34,7 +34,7 @@ func TestRunWithMockFactory(t *testing.T) {
 	localUsername := fmt.Sprintf("-localUsername=%s", config.Credentials.UserName)
 	localPassword := fmt.Sprintf("-localPassword=%s", config.Credentials.Password)
 
-	args := []string{"-cacert=main_test.go", "-logFile=", localAddr, localUsername, localPassword}
+	args := []string{"-caCert=main_test.go", "-logFile=", localAddr, localUsername, localPassword}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -48,7 +48,7 @@ func TestRunErrorWithMockFactory(t *testing.T) {
 
 	localAddr := fmt.Sprintf("-localAddress=%s", config.URL)
 
-	args := []string{"-cacert=main_test.go", "-logFile=", localAddr}
+	args := []string{"-caCert=main_test.go", "-logFile=", localAddr}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/cmd/connector/main_test.go
+++ b/cmd/connector/main_test.go
@@ -35,7 +35,7 @@ func TestRunWithInvalidConfigFile(t *testing.T) {
 }
 
 func TestRunWithNoCA(t *testing.T) {
-	args := []string{"-cacert=invalid.crt"}
+	args := []string{"-caCert=invalid.crt"}
 
 	require.Error(t, run(context.Background(), app.NewMockLauncher, args))
 }

--- a/config/settings_test.go
+++ b/config/settings_test.go
@@ -59,7 +59,7 @@ type TestSettings struct {
 
 	AuthID string `json:"authId,omitempty"`
 
-	CACert    string `json:"cacert,omitempty"`
+	CACert    string `json:"caCert,omitempty"`
 	Cert      string `json:"cert,omitempty"`
 	Key       string `json:"key,omitempty"`
 	TPMKey    string `json:"tpmKey,omitempty"`

--- a/config/testdata/config.json
+++ b/config/testdata/config.json
@@ -1,7 +1,7 @@
 {
 	"deviceId": "config:deviceId",
 	"policyId": "policyId_config",
-	"cacert": "",
+	"caCert": "",
 	"localUsername": "localUsername_config",
 	"localPassword": "localPassword_config",
 	"logFile": "logFile_config",

--- a/config/tls_config.go
+++ b/config/tls_config.go
@@ -31,7 +31,7 @@ func noClean() {
 
 // TLSSettings represents the TLS configuration data.
 type TLSSettings struct {
-	CACert string `json:"cacert"`
+	CACert string `json:"caCert"`
 
 	Cert string `json:"cert"`
 	Key  string `json:"key"`

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	flagCACert = "cacert"
+	flagCACert = "caCert"
 )
 
 var (

--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -54,7 +54,7 @@ func TestFlagsMappings(t *testing.T) {
 		"-localUsername=G",
 		"-localPassword=H",
 		"-authId=I",
-		"-cacert=J",
+		"-caCert=J",
 		"-cert=K",
 		"-key=L",
 		"-tpmKey=M",

--- a/resources/config.json
+++ b/resources/config.json
@@ -1,5 +1,5 @@
 {
-    "cacert": "/etc/suite-connector/iothub.crt",
+    "caCert": "/etc/suite-connector/iothub.crt",
     "provisioningFile": "/etc/suite-connector/provisioning.json",
     "logFile": "/var/log/suite-connector/suite-connector.log"
 }


### PR DESCRIPTION
[#28] cacert configuration property/flag should be caCert

Changed cacert to be caCert

Signed-off-by: Antonia Avramova <antonia.avramova@bosch.io>