### PR TITLE
[#74] Paho log wrapper doesn't add spaces between arguments of Println

### DIFF
--- a/logger/level.go
+++ b/logger/level.go
@@ -119,7 +119,7 @@ type LogLevelDecorator struct {
 
 // Println prints the values with a new line break.
 func (l LogLevelDecorator) Println(v ...interface{}) {
-	l.exporter.Export(l.level, fmt.Sprint(v...))
+	l.exporter.Export(l.level, fmt.Sprintln(v...))
 }
 
 // Printf formats the text while printing the data.

--- a/logger/level_test.go
+++ b/logger/level_test.go
@@ -133,3 +133,16 @@ func TestLogLevelDecorator(t *testing.T) {
 
 	assert.True(t, strings.Contains(output, formatted))
 }
+
+func TestLogLevelDecoratorSpacing(t *testing.T) {
+	const msg = "Message 15 deleted"
+
+	b1 := new(bytes.Buffer)
+	d := NewLevelDecorator(create(b1, "[testing] ", 15), INFO)
+
+	d.Println("Message", 15, "deleted")
+
+	output := b1.String()
+
+	assert.True(t, strings.Contains(output, msg))
+}


### PR DESCRIPTION
[#74] Paho log wrapper doesn't add spaces between arguments of Println

This makes paho logger output difficult to read.