### PR TITLE
Discrepancy when forwarding Hono commands via Suite-Connector

### DIFF
--- a/cmd/connector/launcher.go
+++ b/cmd/connector/launcher.go
@@ -156,7 +156,7 @@ func (l *launcher) Run(
 			<-l.signals
 
 			//Remove all subscriptions for the gateway commands
-			l.manager.Clear()
+			l.manager.RemoveAll()
 
 			honoClient.RemoveConnectionListener(errorsHandler)
 			honoClient.RemoveConnectionListener(connHandler)

--- a/cmd/connector/launcher.go
+++ b/cmd/connector/launcher.go
@@ -150,15 +150,13 @@ func (l *launcher) Run(
 			}
 			defer honoClient.Disconnect()
 
-			commandSub := fmt.Sprintf("command//%s/req/#", settings.DeviceID)
-
 			//Add subscription for the gateway commands
-			l.manager.Add(commandSub)
+			l.manager.Add(fmt.Sprintf("command//%s/req/#", settings.DeviceID))
 
 			<-l.signals
 
-			//Remove subscription for the gateway commands
-			l.manager.Remove(commandSub)
+			//Remove all subscriptions for the gateway commands
+			l.manager.Clear()
 
 			honoClient.RemoveConnectionListener(errorsHandler)
 			honoClient.RemoveConnectionListener(connHandler)

--- a/cmd/connector/launcher.go
+++ b/cmd/connector/launcher.go
@@ -150,12 +150,15 @@ func (l *launcher) Run(
 			}
 			defer honoClient.Disconnect()
 
+			commandSub := fmt.Sprintf("command//%s/req/#", settings.DeviceID)
+
 			//Add subscription for the gateway commands
-			l.manager.Add(fmt.Sprintf("command//%s/req/#", settings.DeviceID))
+			l.manager.Add(commandSub)
 
 			<-l.signals
 
-			l.manager.Remove(fmt.Sprintf("command//%s/req/#", settings.DeviceID))
+			//Remove subscription for the gateway commands
+			l.manager.Remove(commandSub)
 
 			honoClient.RemoveConnectionListener(errorsHandler)
 			honoClient.RemoveConnectionListener(connHandler)

--- a/config/connections.go
+++ b/config/connections.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
 
 	"github.com/eclipse-kanto/suite-connector/logger"
 	"github.com/eclipse-kanto/suite-connector/routing"
@@ -274,6 +275,8 @@ func CreateCloudConnection(
 
 // SetupTracing initializes the messages tracing.
 func SetupTracing(router *message.Router, logger logger.Logger) {
+	router.AddMiddleware(middleware.Recoverer)
+
 	tracingPrefixes := os.Getenv("TRACE_TOPIC_PREFIX")
 	if len(tracingPrefixes) > 0 {
 		router.AddMiddleware(conn.NewTrace(logger, strings.Split(tracingPrefixes, ",")))

--- a/connector/subscription_manager.go
+++ b/connector/subscription_manager.go
@@ -30,13 +30,14 @@ type SubscriptionManager interface {
 }
 
 type subscriptionManager struct {
-	topics sync.Map
+	topics map[string]int
+	lock   sync.Mutex
 
 	conn atomic.Value
 }
 
 func (m *subscriptionManager) Add(topic string) bool {
-	if _, ok := m.topics.LoadOrStore(topic, true); !ok {
+	if m.add0(topic) {
 		if connRef := m.conn.Load(); connRef != nil {
 			conn := connRef.(*MQTTConnection)
 			conn.subscribe(nil, QosAtMostOnce, topic)
@@ -46,8 +47,21 @@ func (m *subscriptionManager) Add(topic string) bool {
 	return false
 }
 
+func (m *subscriptionManager) add0(topic string) bool {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if c, ok := m.topics[topic]; ok {
+		m.topics[topic] = c + 1
+		return false
+	}
+
+	m.topics[topic] = 1
+	return true
+}
+
 func (m *subscriptionManager) Remove(topic string) bool {
-	if _, ok := m.topics.LoadAndDelete(topic); ok {
+	if m.remove0(topic) {
 		if connRef := m.conn.Load(); connRef != nil {
 			conn := connRef.(*MQTTConnection)
 			conn.unsubscribe(topic, true)
@@ -57,17 +71,46 @@ func (m *subscriptionManager) Remove(topic string) bool {
 	return false
 }
 
+func (m *subscriptionManager) remove0(topic string) bool {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if c, ok := m.topics[topic]; ok {
+		if c > 1 {
+			m.topics[topic] = c - 1
+			return false
+		}
+		delete(m.topics, topic)
+		return true
+	}
+
+	return false
+}
+
 func (m *subscriptionManager) ForwardTo(conn *MQTTConnection) {
 	m.conn.Store(conn)
 
-	m.topics.Range(func(key, value interface{}) bool {
-		topic := key.(string)
+	topics := m.copyTopics()
+
+	for _, topic := range topics {
 		conn.subscribe(nil, QosAtMostOnce, topic)
-		return true
-	})
+	}
+}
+
+func (m *subscriptionManager) copyTopics() []string {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	result := make([]string, 0)
+	for topic := range m.topics {
+		result = append(result, topic)
+	}
+	return result
 }
 
 // NewSubscriptionManager creates subscriptions manager.
 func NewSubscriptionManager() SubscriptionManager {
-	return new(subscriptionManager)
+	return &subscriptionManager{
+		topics: make(map[string]int),
+	}
 }

--- a/connector/subscription_manager.go
+++ b/connector/subscription_manager.go
@@ -25,8 +25,8 @@ type SubscriptionManager interface {
 	// Remove removes a subscription for the provided topic. Returns true if it does exist and was successfully unsubscribed.
 	Remove(topic string) bool
 
-	// Remove removes all subscriptions.
-	Clear()
+	// RemoveAll removes all subscriptions.
+	RemoveAll()
 
 	// ForwardTo specifies the connection to which should be the messages forwarded.
 	ForwardTo(conn *MQTTConnection)
@@ -90,7 +90,7 @@ func (m *subscriptionManager) remove0(topic string) bool {
 	return false
 }
 
-func (m *subscriptionManager) Clear() {
+func (m *subscriptionManager) RemoveAll() {
 	topics := m.copyTopics(true)
 
 	if connRef := m.conn.Load(); connRef != nil {

--- a/connector/subscription_manager_test.go
+++ b/connector/subscription_manager_test.go
@@ -62,3 +62,23 @@ func TestRemoveSubscription(t *testing.T) {
 	assert.False(t, m.Remove(topicClientsTotal))
 	assert.False(t, m.Remove(topicClientsTotal))
 }
+
+func TestClearSubscriptions(t *testing.T) {
+	m := connector.NewSubscriptionManager()
+
+	config, err := testutil.NewLocalConfig()
+	config.CleanSession = true
+	require.NoError(t, err)
+
+	pubClient, err := connector.NewMQTTConnection(
+		config, "",
+		testutil.NewLogger("connector", logger.INFO, t),
+	)
+	require.NoError(t, err)
+
+	m.ForwardTo(pubClient)
+
+	assert.True(t, m.Add(topicClientsTotal))
+	m.Clear()
+	assert.False(t, m.Remove(topicClientsTotal))
+}

--- a/connector/subscription_manager_test.go
+++ b/connector/subscription_manager_test.go
@@ -47,8 +47,10 @@ func TestAddSubscription(t *testing.T) {
 
 	assert.True(t, m.Add(topicClientsTotal))
 	assert.False(t, m.Add(topicClientsTotal))
+	assert.False(t, m.Remove(topicClientsTotal))
 	assert.True(t, m.Remove(topicClientsTotal))
 	assert.True(t, m.Add(topicClientsTotal))
+	assert.True(t, m.Remove(topicClientsTotal))
 }
 
 func TestRemoveSubscription(t *testing.T) {

--- a/connector/subscription_manager_test.go
+++ b/connector/subscription_manager_test.go
@@ -63,7 +63,7 @@ func TestRemoveSubscription(t *testing.T) {
 	assert.False(t, m.Remove(topicClientsTotal))
 }
 
-func TestClearSubscriptions(t *testing.T) {
+func TestRemoveAllSubscriptions(t *testing.T) {
 	m := connector.NewSubscriptionManager()
 
 	config, err := testutil.NewLocalConfig()
@@ -79,6 +79,6 @@ func TestClearSubscriptions(t *testing.T) {
 	m.ForwardTo(pubClient)
 
 	assert.True(t, m.Add(topicClientsTotal))
-	m.Clear()
+	m.RemoveAll()
 	assert.False(t, m.Remove(topicClientsTotal))
 }

--- a/routing/subscription_test.go
+++ b/routing/subscription_test.go
@@ -116,8 +116,6 @@ func TestLogHandlerAccept(t *testing.T) {
 	msg.SetContext(connector.SetTopicToCtx(context.Background(), routing.TopicLogSubscribe))
 	assert.NoError(t, h.ProcessLogs(msg))
 	assert.Equal(t, 1, h.SubcriptionList.Len())
-	assert.NoError(t, h.ProcessLogs(msg))
-	assert.Equal(t, 1, h.SubcriptionList.Len())
 	msg = message.NewMessage(watermill.NewUUID(), []byte("1635966265: dummy command//Testing:Logs/req/#"))
 	msg.SetContext(connector.SetTopicToCtx(context.Background(), routing.TopicLogUnsubscribe))
 	assert.NoError(t, h.ProcessLogs(msg))

--- a/util/utils.go
+++ b/util/utils.go
@@ -22,14 +22,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-// NormalizeTopic convert command topics to short form
+// NormalizeTopic convert command topics to long form
 func NormalizeTopic(topic string) string {
-	if strings.HasPrefix(topic, "command/") {
-		topic = strings.Replace(topic, "command", "c", 1)
+	if strings.HasPrefix(topic, "c//") {
+		topic = strings.Replace(topic, "c", "command", 1)
 	}
 
-	if strings.HasSuffix(topic, "/req/#") {
-		topic = strings.Replace(topic, "/req/#", "/q/#", 1)
+	if strings.HasSuffix(topic, "/q/#") {
+		topic = strings.Replace(topic, "/q/#", "/req/#", 1)
 	}
 	return topic
 }

--- a/util/utils_test.go
+++ b/util/utils_test.go
@@ -24,14 +24,14 @@ import (
 )
 
 func TestNormalizing(t *testing.T) {
-	message := util.NormalizeTopic("command//4711 /req/#")
-	assert.Equal(t, message, "c//4711 /q/#")
+	message := util.NormalizeTopic("c//4711 /q/#")
+	assert.Equal(t, message, "command//4711 /req/#")
 
-	message = util.NormalizeTopic("command//4711 /q/#")
-	assert.Equal(t, message, "c//4711 /q/#")
+	message = util.NormalizeTopic("c///q/#")
+	assert.Equal(t, message, "command///req/#")
 
-	message = util.NormalizeTopic("c//4711 /req/#")
-	assert.Equal(t, message, "c//4711 /q/#")
+	message = util.NormalizeTopic("command//4711 /req/#")
+	assert.Equal(t, message, "command//4711 /req/#")
 }
 
 func TestParseCmdTopic(t *testing.T) {


### PR DESCRIPTION
[#41]  Discrepancy when forwarding Hono commands via Suite-Connector

Removed wildcard subscription:
 `command//+/req/#`.
Now it's possible to subscribe for gateway commands with or without gatewayid in the topic:
`command//<device-id>/req/# or command///req/# `