### PR TITLE
All events/telemetry should be routed to a single topic

### DIFF
--- a/cmd/connector/launcher.go
+++ b/cmd/connector/launcher.go
@@ -91,7 +91,8 @@ func (l *launcher) Run(
 	mosquittoSub := conn.NewSubscriber(cloudClient, conn.QosAtLeastOnce, false, logger, nil)
 	routing.CommandsResBus(router, honoPub, mosquittoSub, reqCache, settings.DeviceID)
 
-	routing.EventsBus(router, honoPub, mosquittoSub)
+	routing.EventsBus(router, honoPub, mosquittoSub, settings.TenantID, settings.DeviceID)
+	routing.TelemetryBus(router, honoPub, mosquittoSub, settings.TenantID, settings.DeviceID)
 
 	routing.CommandsReqBus(router,
 		conn.NewPublisher(cloudClient, conn.QosAtLeastOnce, logger, nil),

--- a/routing/commands_test.go
+++ b/routing/commands_test.go
@@ -61,7 +61,7 @@ func TestCommandHandlersTestSuite(t *testing.T) {
 func (s *CommandHandlersTestSuite) SetupSuite() {
 	s.reqCache = cache.NewTTLCache()
 	s.requestHandler = routing.NewCommandRequestHandler(s.reqCache, deviceId)
-	s.responseHandler = routing.NewCommandResponseHandler(s.reqCache, deviceId)
+	s.responseHandler = routing.NewCommandResponseHandler(s.reqCache, "", deviceId)
 
 	response.Delete()
 }

--- a/routing/errors.go
+++ b/routing/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Contributors to the Eclipse Foundation
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/routing/errors.go
+++ b/routing/errors.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+package routing
+
+import (
+	"github.com/pkg/errors"
+)
+
+var (
+	errNoTopic = errors.New("no MQTT topic")
+)

--- a/routing/events.go
+++ b/routing/events.go
@@ -13,39 +13,120 @@
 package routing
 
 import (
+	"os"
+	"strings"
+
 	"github.com/ThreeDotsLabs/watermill/message"
 
 	"github.com/eclipse-kanto/suite-connector/connector"
 )
 
 const (
-	// TopicsEvent defines events and telemetry topics
-	TopicsEvent = "event/#,e/#,telemetry/#,t/#"
+	// TopicsEvent defines event topics
+	TopicsEvent = "event/#,e/#"
 
 	// TopicsTelemetry defines telemetry topics
 	TopicsTelemetry = "telemetry/#,t/#"
 )
 
-// EventsBus creates bus for events and telemetry messages.
-func EventsBus(router *message.Router, honoPub message.Publisher, mosquittoSub message.Subscriber) *message.Handler {
+type eventsHandler struct {
+	prefix   string
+	tenantID string
+	deviceID string
+}
+
+// NewEventsHandler returns the events handler function.
+func NewEventsHandler(prefix string, tenantID string, deviceID string) message.HandlerFunc {
+	h := &eventsHandler{
+		prefix:   prefix,
+		tenantID: tenantID,
+		deviceID: deviceID,
+	}
+
+	return h.HandleEvent
+}
+
+func (h *eventsHandler) HandleEvent(msg *message.Message) ([]*message.Message, error) {
+	if topic, ok := connector.TopicFromCtx(msg.Context()); ok {
+		msgType := "event"
+		tenID := h.tenantID
+		devID := h.deviceID
+
+		segments := strings.Split(topic, "/")
+
+		if segments[0] == "telemetry" || segments[0] == "t" {
+			msgType = "telemetry"
+		}
+
+		if len(segments) > 1 && len(segments[1]) > 0 {
+			tenID = segments[1]
+		}
+
+		if len(segments) > 2 && len(segments[2]) > 0 {
+			devID = segments[2]
+		}
+
+		var buff strings.Builder
+		buff.Grow(64)
+
+		if len(h.prefix) > 0 {
+			buff.WriteString(h.prefix)
+			buff.WriteString("/")
+		}
+
+		buff.WriteString(msgType)
+		buff.WriteString("/")
+		buff.WriteString(tenID)
+		buff.WriteString("/")
+		buff.WriteString(devID)
+
+		//Fix missing suffix
+		for i := 3; i < len(segments); i++ {
+			buff.WriteString("/")
+			buff.WriteString(segments[i])
+		}
+
+		msg.SetContext(connector.SetTopicToCtx(msg.Context(), buff.String()))
+
+		return []*message.Message{msg}, nil
+	}
+	return nil, errNoTopic
+}
+
+// EventsBus creates bus for events messages.
+func EventsBus(router *message.Router,
+	honoPub message.Publisher,
+	mosquittoSub message.Subscriber,
+	tenantID string,
+	deviceID string,
+) *message.Handler {
+	prefix := os.Getenv("EVENTS_TOPIC_PREFIX")
+
 	//Gateway -> Mosquitto Broker -> Message bus -> Hono
 	return router.AddHandler("events_bus",
 		TopicsEvent,
 		mosquittoSub,
 		connector.TopicEmpty,
 		honoPub,
-		message.PassthroughHandler,
+		NewEventsHandler(prefix, tenantID, deviceID),
 	)
 }
 
 // TelemetryBus creates bus for telemetry messages.
-func TelemetryBus(router *message.Router, honoPub message.Publisher, mosquittoSub message.Subscriber) *message.Handler {
+func TelemetryBus(router *message.Router,
+	honoPub message.Publisher,
+	mosquittoSub message.Subscriber,
+	tenantID string,
+	deviceID string,
+) *message.Handler {
+	prefix := os.Getenv("TELEMETRY_TOPIC_PREFIX")
+
 	//Gateway -> Mosquitto Broker -> Message bus -> Hono
 	return router.AddHandler("telemetry_bus",
 		TopicsTelemetry,
 		mosquittoSub,
 		connector.TopicEmpty,
 		honoPub,
-		message.PassthroughHandler,
+		NewEventsHandler(prefix, tenantID, deviceID),
 	)
 }

--- a/routing/it_events_test.go
+++ b/routing/it_events_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2021 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+
+//go:build (local_integration && ignore) || !unit
+
+package routing_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/ThreeDotsLabs/watermill/message/subscriber"
+	"github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
+	"go.uber.org/goleak"
+
+	"github.com/eclipse-kanto/suite-connector/connector"
+	"github.com/eclipse-kanto/suite-connector/logger"
+	"github.com/eclipse-kanto/suite-connector/routing"
+	"github.com/eclipse-kanto/suite-connector/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventsBus(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	logger := testutil.NewLogger("events", logger.ERROR, t)
+
+	config, err := testutil.NewLocalConfig()
+	config.CleanSession = true
+	require.NoError(t, err)
+
+	client, err := connector.NewMQTTConnection(
+		config, "",
+		logger,
+	)
+	require.NoError(t, err)
+
+	future := client.Connect()
+	<-future.Done()
+	require.NoError(t, future.Error())
+
+	defer func() {
+		client.Disconnect()
+		time.Sleep(time.Second)
+	}()
+
+	router, err := message.NewRouter(message.RouterConfig{}, logger)
+	require.NoError(t, err)
+
+	source := connector.NewSubscriber(client, connector.QosAtLeastOnce, false, logger, nil)
+	defer source.Close()
+
+	sink := gochannel.NewGoChannel(
+		gochannel.Config{
+			Persistent:          true,
+			OutputChannelBuffer: int64(16),
+		},
+		logger,
+	)
+
+	routing.EventsBus(router, sink, source, "testTenant", "testDevice")
+	routing.TelemetryBus(router, sink, source, "testTenant", "testDevice")
+
+	done := make(chan bool, 1)
+	go func() {
+		defer func() {
+			done <- true
+		}()
+
+		if err := router.Run(context.Background()); err != nil {
+			logger.Error("Failed to create cloud router", err, nil)
+		}
+	}()
+
+	defer func() {
+		router.Close()
+
+		<-done
+	}()
+
+	<-router.Running()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sMsg, err := sink.Subscribe(ctx, connector.TopicEmpty)
+	require.NoError(t, err)
+
+	msg := message.NewMessage("hello", []byte("{}"))
+	pub := connector.NewPublisher(client, connector.QosAtLeastOnce, logger, nil)
+	require.NoError(t, pub.Publish("event/testTenant/testDevice", msg))
+
+	receivedMsgs, ok := subscriber.BulkRead(sMsg, 1, time.Second*5)
+	require.True(t, ok)
+	for _, msg := range receivedMsgs {
+		assert.Equal(t, "{}", string(msg.Payload))
+	}
+}

--- a/routing/it_events_test.go
+++ b/routing/it_events_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Contributors to the Eclipse Foundation
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.


### PR DESCRIPTION
[#78] All events/telemetry should be routed to a single topic

This is needed to simplify back-end logic handling events and telemetry.