### PR TITLE
Add ALPN support

### DIFF
--- a/config/tls_config.go
+++ b/config/tls_config.go
@@ -32,10 +32,10 @@ func noClean() {
 
 // TLSSettings represents the TLS configuration data.
 type TLSSettings struct {
-	CACert string `json:"caCert"`
-	Cert   string `json:"cert"`
-	Key    string `json:"key"`
-	Alpn   string `json:"alpn"`
+	CACert string   `json:"caCert"`
+	Cert   string   `json:"cert"`
+	Key    string   `json:"key"`
+	Alpn   []string `json:"alpn"`
 
 	TPMKey    string `json:"tpmKey"`
 	TPMKeyPub string `json:"tpmKeyPub"`
@@ -51,7 +51,9 @@ func NewHubTLSConfig(settings *TLSSettings, logger watermill.LoggerAdapter) (*tl
 	}
 
 	if len(settings.Alpn) > 0 {
-		cfg.NextProtos = []string{settings.Alpn}
+		alpn := make([]string, len(settings.Alpn))
+		copy(alpn, settings.Alpn)
+		cfg.NextProtos = alpn
 	}
 
 	return cfg, clean, err

--- a/config/tls_config_test.go
+++ b/config/tls_config_test.go
@@ -74,7 +74,7 @@ func TestCertificateSettingsWithAlpn(t *testing.T) {
 		CACert: certFile,
 		Cert:   certFile,
 		Key:    keyFile,
-		Alpn:   "x-test",
+		Alpn:   []string{"x-test"},
 	}
 
 	cfg, clean, err := config.NewHubTLSConfig(settings, logger)

--- a/config/tls_config_test.go
+++ b/config/tls_config_test.go
@@ -64,6 +64,28 @@ func TestUseCertificateSettingsOK(t *testing.T) {
 	defer clean()
 }
 
+func TestCertificateSettingsWithAlpn(t *testing.T) {
+	certFile := "testdata/certificate.pem"
+	keyFile := "testdata/key.pem"
+
+	logger := watermill.NopLogger{}
+
+	settings := &config.TLSSettings{
+		CACert: certFile,
+		Cert:   certFile,
+		Key:    keyFile,
+		Alpn:   "x-test",
+	}
+
+	cfg, clean, err := config.NewHubTLSConfig(settings, logger)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	defer clean()
+
+	require.Equal(t, 1, len(cfg.NextProtos))
+	assert.Equal(t, "x-test", cfg.NextProtos[0])
+}
+
 func TestUseCertificateSettingsFail(t *testing.T) {
 	certFile := "testdata/certificate.pem"
 	keyFile := "testdata/key.pem"

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -120,6 +120,10 @@ func AddTLS(f *flag.FlagSet, settings, def *config.TLSSettings) {
 		"key", def.Key,
 		"A PEM encoded unencrypted private key `file` for cloud access",
 	)
+	f.StringVar(&settings.Alpn,
+		"alpn", def.Alpn,
+		"TLS application layer protocol negotiation option for cloud access",
+	)
 	f.StringVar(&settings.TPMKey,
 		"tpmKey", def.TPMKey,
 		"Private part of TPM2 key `file`",

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -120,9 +120,9 @@ func AddTLS(f *flag.FlagSet, settings, def *config.TLSSettings) {
 		"key", def.Key,
 		"A PEM encoded unencrypted private key `file` for cloud access",
 	)
-	f.StringVar(&settings.Alpn,
-		"alpn", def.Alpn,
-		"TLS application layer protocol negotiation option for cloud access",
+	f.Var(NewStringSliceV(&settings.Alpn),
+		"alpn",
+		"TLS application layer protocol negotiation options space separated for cloud access",
 	)
 	f.StringVar(&settings.TPMKey,
 		"tpmKey", def.TPMKey,

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -108,6 +108,10 @@ func AddHub(f *flag.FlagSet, settings, def *config.HubConnectionSettings) {
 
 // AddTLS add the TLS connection related flags.
 func AddTLS(f *flag.FlagSet, settings, def *config.TLSSettings) {
+	f.Var(NewStringSliceV(&settings.Alpn),
+		"alpn",
+		"TLS application layer protocol negotiation options space separated for cloud access",
+	)
 	f.StringVar(&settings.CACert,
 		flagCACert, def.CACert,
 		"A PEM encoded CA certificates `file`",
@@ -119,10 +123,6 @@ func AddTLS(f *flag.FlagSet, settings, def *config.TLSSettings) {
 	f.StringVar(&settings.Key,
 		"key", def.Key,
 		"A PEM encoded unencrypted private key `file` for cloud access",
-	)
-	f.Var(NewStringSliceV(&settings.Alpn),
-		"alpn",
-		"TLS application layer protocol negotiation options space separated for cloud access",
 	)
 	f.StringVar(&settings.TPMKey,
 		"tpmKey", def.TPMKey,

--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -58,6 +58,7 @@ func TestFlagsMappings(t *testing.T) {
 		"-authId=I",
 		"-caCert=J",
 		"-cert=K",
+		"-alpn=U",
 		"-key=L",
 		"-tpmKey=M",
 		"-tpmKeyPub=N",
@@ -91,6 +92,7 @@ func TestFlagsMappings(t *testing.T) {
 	assert.Equal(t, "J", cmd.CACert)
 	assert.Equal(t, "K", cmd.Cert)
 	assert.Equal(t, "L", cmd.Key)
+	assert.Equal(t, "U", cmd.Alpn)
 	assert.Equal(t, "M", cmd.TPMKey)
 	assert.Equal(t, "N", cmd.TPMKeyPub)
 	assert.EqualValues(t, 0x1234, cmd.TPMHandle)

--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -92,7 +92,7 @@ func TestFlagsMappings(t *testing.T) {
 	assert.Equal(t, "J", cmd.CACert)
 	assert.Equal(t, "K", cmd.Cert)
 	assert.Equal(t, "L", cmd.Key)
-	assert.Equal(t, "U", cmd.Alpn)
+	assert.Equal(t, []string{"U"}, cmd.Alpn)
 	assert.Equal(t, "M", cmd.TPMKey)
 	assert.Equal(t, "N", cmd.TPMKeyPub)
 	assert.EqualValues(t, 0x1234, cmd.TPMHandle)


### PR DESCRIPTION
[#83] Add ALPN support

TLS ALPN extension setting is needed to connect to cloud MQTT brokers through firewalls on port 443 and proxies which support HTTP/2