### PR TITLE
Add ALPN support

### DIFF
--- a/config/tls_config.go
+++ b/config/tls_config.go
@@ -32,10 +32,10 @@ func noClean() {
 
 // TLSSettings represents the TLS configuration data.
 type TLSSettings struct {
-	CACert string `json:"caCert"`
-
-	Cert string `json:"cert"`
-	Key  string `json:"key"`
+	CACert string   `json:"caCert"`
+	Cert   string   `json:"cert"`
+	Key    string   `json:"key"`
+	Alpn   []string `json:"alpn"`
 
 	TPMKey    string `json:"tpmKey"`
 	TPMKeyPub string `json:"tpmKeyPub"`
@@ -45,29 +45,18 @@ type TLSSettings struct {
 
 // NewHubTLSConfig initializes the Hub TLS.
 func NewHubTLSConfig(settings *TLSSettings, logger watermill.LoggerAdapter) (*tls.Config, Cleaner, error) {
-	caCertPool, err := NewCAPool(settings.CACert)
+	cfg, clean, err := newHubTLSConfig0(settings, logger)
 	if err != nil {
-		return nil, nil, err
+		return nil, clean, err
 	}
 
-	if len(settings.TPMDevice) > 0 {
-		return NewTPMTlsConfig(settings, caCertPool, logger)
+	if len(settings.Alpn) > 0 {
+		alpn := make([]string, len(settings.Alpn))
+		copy(alpn, settings.Alpn)
+		cfg.NextProtos = alpn
 	}
 
-	if len(settings.Cert) > 0 || len(settings.Key) > 0 {
-		cfg, err := NewFSTlsConfig(caCertPool, settings.Cert, settings.Key)
-		return cfg, noClean, err
-	}
-
-	cfg := &tls.Config{
-		InsecureSkipVerify: false,
-		RootCAs:            caCertPool,
-		MinVersion:         tls.VersionTLS12,
-		MaxVersion:         tls.VersionTLS13,
-		CipherSuites:       supportedCipherSuites(),
-	}
-
-	return cfg, noClean, nil
+	return cfg, clean, err
 }
 
 // NewLocalTLSConfig initializes the Local broker TLS.
@@ -173,6 +162,32 @@ func NewTPMTlsConfig(
 	}
 
 	return tlsConfig, closer, nil
+}
+
+func newHubTLSConfig0(settings *TLSSettings, logger watermill.LoggerAdapter) (*tls.Config, Cleaner, error) {
+	caCertPool, err := NewCAPool(settings.CACert)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(settings.TPMDevice) > 0 {
+		return NewTPMTlsConfig(settings, caCertPool, logger)
+	}
+
+	if len(settings.Cert) > 0 || len(settings.Key) > 0 {
+		cfg, err := NewFSTlsConfig(caCertPool, settings.Cert, settings.Key)
+		return cfg, noClean, err
+	}
+
+	cfg := &tls.Config{
+		InsecureSkipVerify: false,
+		RootCAs:            caCertPool,
+		MinVersion:         tls.VersionTLS12,
+		MaxVersion:         tls.VersionTLS13,
+		CipherSuites:       supportedCipherSuites(),
+	}
+
+	return cfg, noClean, nil
 }
 
 func supportedCipherSuites() []uint16 {

--- a/config/tls_config_test.go
+++ b/config/tls_config_test.go
@@ -64,6 +64,28 @@ func TestUseCertificateSettingsOK(t *testing.T) {
 	defer clean()
 }
 
+func TestCertificateSettingsWithAlpn(t *testing.T) {
+	certFile := "testdata/certificate.pem"
+	keyFile := "testdata/key.pem"
+
+	logger := watermill.NopLogger{}
+
+	settings := &config.TLSSettings{
+		CACert: certFile,
+		Cert:   certFile,
+		Key:    keyFile,
+		Alpn:   []string{"x-test"},
+	}
+
+	cfg, clean, err := config.NewHubTLSConfig(settings, logger)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	defer clean()
+
+	require.Equal(t, 1, len(cfg.NextProtos))
+	assert.Equal(t, "x-test", cfg.NextProtos[0])
+}
+
 func TestUseCertificateSettingsFail(t *testing.T) {
 	certFile := "testdata/certificate.pem"
 	keyFile := "testdata/key.pem"

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -108,6 +108,10 @@ func AddHub(f *flag.FlagSet, settings, def *config.HubConnectionSettings) {
 
 // AddTLS add the TLS connection related flags.
 func AddTLS(f *flag.FlagSet, settings, def *config.TLSSettings) {
+	f.Var(NewStringSliceV(&settings.Alpn),
+		"alpn",
+		"TLS application layer protocol negotiation options space separated for cloud access",
+	)
 	f.StringVar(&settings.CACert,
 		flagCACert, def.CACert,
 		"A PEM encoded CA certificates `file`",

--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -58,6 +58,7 @@ func TestFlagsMappings(t *testing.T) {
 		"-authId=I",
 		"-caCert=J",
 		"-cert=K",
+		"-alpn=U",
 		"-key=L",
 		"-tpmKey=M",
 		"-tpmKeyPub=N",
@@ -91,6 +92,7 @@ func TestFlagsMappings(t *testing.T) {
 	assert.Equal(t, "J", cmd.CACert)
 	assert.Equal(t, "K", cmd.Cert)
 	assert.Equal(t, "L", cmd.Key)
+	assert.Equal(t, []string{"U"}, cmd.Alpn)
 	assert.Equal(t, "M", cmd.TPMKey)
 	assert.Equal(t, "N", cmd.TPMKeyPub)
 	assert.EqualValues(t, 0x1234, cmd.TPMHandle)


### PR DESCRIPTION
[#83] Add ALPN support

TLS ALPN extension setting is needed to connect to cloud MQTT brokers through firewalls on port 443 and proxies which support HTTP/2